### PR TITLE
Remove the blog routes (they're now in wp-endpoints-routes)

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -16,37 +16,7 @@ class Api
 		Endpoints\Post::init();
 		Endpoints\StaticApi::init();
 
-		add_filter( 'ln_endpoints_data_routes', [ __CLASS__, 'add_extra_routes' ] );
-
 		add_filter( 'allowed_http_origin', [ __CLASS__, 'gform_allowed_http_origin' ] );
-	}
-
-	/**
-	 * Add extra routes the the endpoint
-	 *
-	 * @param array $routes The current set of routes.
-	 * @return mixed
-	 */
-	public static function add_extra_routes( $routes ) {
-		$extra_routes = [
-			[
-				'state' => 'blogIndex',
-				'url' => '/blog/',
-				'template' => 'blog',
-				'endpoint' => 'collection',
-				'params' => [
-					/* Add additional params here */
-				],
-			],
-			[
-				'state' => 'blogPost',
-				'url' => '/blog/:slug',
-				'template' => 'blog-single',
-				'endpoint' => 'post',
-			],
-		];
-
-		return array_merge( $routes, $extra_routes );
 	}
 
 	/**


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)
  Feature update
- **What is the current behavior?** (You can also link to an open issue
  here)
  Blog routes hardcoded into plugin
- **What is the new behavior (if this is a feature change)?**
  Routes are generated by the routes endpoint packages
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)
  No
- **Other information**:
