### PR TITLE
Update php version to match the one in our servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 sudo: false
 php:
-  - 5.4
+  - 5.6
 
 before_script:
   - composer self-update -q


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)

This updates the php version set in travis
- **What is the current behavior?** (You can also link to an open issue
  here)

Current PHP version is 5.4
- **What is the new behavior (if this is a feature change)?**

PHP version 5.6 on travis
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)

No
- **Other information**:
