### PR TITLE
Error503

### DIFF
--- a/PluginSetup.php
+++ b/PluginSetup.php
@@ -54,8 +54,21 @@ class PluginSetup {
 				'Plugin %s requires WordPress %s or higher.',
 				LEANP_TEXT_DOMAIN
 			), LEANP_PLUGIN_VERSION, LEANP_MINIMUM_WP_VERSION );
+
 			trigger_error( esc_html( $msg ), E_USER_ERROR );
 
+		}
+	}
+
+	/**
+	 * Dependency checks
+	 */
+	public static function check_dependencies() {
+		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
+		if ( ! is_plugin_active( 'advanced-custom-fields-pro/acf.php' )
+			|| ! is_plugin_active( 'rest-api/plugin.php' ) ) {
+			wp_die( 'Service temporarily unavailable', 503 );
 		}
 	}
 

--- a/PluginSetup.php
+++ b/PluginSetup.php
@@ -50,19 +50,12 @@ class PluginSetup {
 
 		if ( version_compare( $wp_version, LEANP_MINIMUM_WP_VERSION, '<' ) ) {
 
-			deactivate_plugins( LEANP_PLUGIN_NAME );
+			$msg = sprintf( __(
+				'Plugin %s requires WordPress %s or higher.',
+				LEANP_TEXT_DOMAIN
+			), LEANP_PLUGIN_VERSION, LEANP_MINIMUM_WP_VERSION );
+			trigger_error( esc_html( $msg ), E_USER_ERROR );
 
-			echo wp_kses(
-				sprintf(
-					esc_html__(
-						'Plugin %s requires WordPress %s or higher.',
-						LEANP_TEXT_DOMAIN
-					), LEANP_API_VERSION, LEANP_MINIMUM_WP_VERSION
-				),
-				array()
-			);
-			wp_die();
-			exit;
 		}
 	}
 

--- a/leanp.php
+++ b/leanp.php
@@ -24,4 +24,5 @@ require_once LEANP_PLUGIN_DIR . 'PluginSetup.php';
 $class_name = __NAMESPACE__ . '\\PluginSetup';
 register_activation_hook( __FILE__, array( $class_name, 'maybe_deactivate' ) );
 register_deactivation_hook( __FILE__, array( $class_name, 'flush_rewrite_rules' ) );
+add_action( 'rest_api_init', array( $class_name, 'check_dependencies' ) );
 $class_name::init();


### PR DESCRIPTION
- This is a new feature that makes the rest api return 503 service temporarily unavailable when ACF or the API plugins are not enabled. 

I also took the chance to do the WP minimum version check properly.
- Currently we end up with a blank page when one of these 2 plugins are not available. 
- With this change, we can communicate the problem to the NG app and it can display an error page instead of a blank page.
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)
- **Other information**:
